### PR TITLE
Do not call onReady if addon is installing

### DIFF
--- a/platform/firefox/bootstrap.js
+++ b/platform/firefox/bootstrap.js
@@ -86,7 +86,7 @@ function startup(data, reason) {
         );
     };
 
-    if ( reason !== APP_STARTUP ) {
+    if ( reason !== APP_STARTUP && reason !== ADDON_INSTALL) {
         onReady();
         return;
     }


### PR DESCRIPTION
If the uBlock extension is installed globally for all users on a machine, a user's first run of Firefox will fail to load uBlock because the call to appShell.hiddenDOMWindow will throw an exception. A second run of Firefox will load uBlock successfully.
